### PR TITLE
Check the size argument before using it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21.3,22,23]
+        otp_version: [22,23,24]
         os: [ubuntu-latest]
 
     container:

--- a/src/ringbuffer_process.erl
+++ b/src/ringbuffer_process.erl
@@ -168,7 +168,7 @@ read_wait(Name, Size, Skipped, R, Try) ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 
-init([Name, Size]) ->
+init([Name, Size]) when is_integer(Size) andalso Size > 0 ->
     Options = [
         set,
         named_table,


### PR DESCRIPTION
Zotonic did not have a default setting for the size argument, so `undefined` was passed and used.